### PR TITLE
Show .efi files by default

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -111,7 +111,7 @@ VOID OnBrowseClick(
 {
     WCHAR szFileName[MAX_PATH + 1];
     LPCWSTR lpOpenDialogFilter =
-        TEXT("Image files (*.exe; *.dll; *.sys)\0*.exe;*.dll;*.sys\0All files (*.*)\0*.*\0\0");
+        TEXT("Image files (*.exe; *.dll; *.sys, *.efi)\0*.exe;*.dll;*.sys;*.efi\0All files (*.*)\0*.*\0\0");
 
     RtlSecureZeroMemory(szFileName, sizeof(szFileName));
     if (supOpenDialogExecute(hwndDlg,


### PR DESCRIPTION
EFI executables (applications and drivers) are also PE/COFF files and are signed with Authenticode signatures.
For use in SecureBoot environments they are signed and their Authenticode hashes are used for inclusion in db (allowlist) and dbx (denylist).